### PR TITLE
Install ERD URLs ConfigMap as pre-install hook

### DIFF
--- a/templates/find-service/pre-install/backend-configmap.yaml
+++ b/templates/find-service/pre-install/backend-configmap.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: erd-urls
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "0"
 data:
   INCIDENT_SERVICE_URL: {{ .Values.erdemo.incidentService | quote }}
   MISSION_SERVICE_URL: {{ .Values.erdemo.missionService | quote }}


### PR DESCRIPTION
Install the `ConfigMap` that holds the Emergency Response Demo URLs before the application installation starts, using the `pre-install` helm hook.